### PR TITLE
FIX: do not assume there is a global args

### DIFF
--- a/xicam/plugins/__init__.py
+++ b/xicam/plugins/__init__.py
@@ -13,7 +13,7 @@ from yapsy.PluginManager import PluginManager
 import xicam
 from xicam.core import msg
 from xicam.core import threads
-from xicam.args import args
+from xicam.args import parse_args
 
 from .datahandlerplugin import DataHandlerPlugin
 from .catalogplugin import CatalogPlugin
@@ -99,7 +99,13 @@ class XicamPluginManager(PluginManager):
             )
 
         self.blacklist = []
-        if args.nocammart:
+        try:
+            args = parse_args(exit_on_fail=False)
+            include_cammart = not args.nocammart
+        except RuntimeError:
+            include_cammart = False
+
+        if not include_cammart:
             self.blacklist.extend(['cammart', 'venvs'])
 
         self.setCategoriesFilter(categoriesfilter)


### PR DESCRIPTION
There is no way not to parse the CLI args on import in this module so
do so in a forgiving way.

Follow on to https://github.com/synchrotrons/Xi-cam/pull/53