### PR TITLE
Pin dependency databroker >=1.0.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=["yapsy", "astropy", "signalslot", "virtualenv", "requests", "appdirs", "xicam.core",
-                      "entrypoints", "databroker"],
+                      "entrypoints", "databroker >=1.0.0"],
     setup_requires=[],
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This ensures that if Xi-cam is installed into an existing environment that
has an older version of databroker, databroker will be updated.